### PR TITLE
docs: rename to open-source-practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can ask questions by raising an [issue](https://github.com/EddieHubCommunity
 
 **3. Create a new branch:**
 
-- Your username would make a good branch because it's unique. ![git-checkout](https://github.com/AmanxUpadhyay/open-source-practice/assets/76415079/68ab0380-c731-4e67-bccc-b666da5dd174)
+- Your username would make a good branch because it's unique. ![git-checkout](https://github.com/AmanxUpadhyay/hacktoberfest-practice/assets/76415079/68ab0380-c731-4e67-bccc-b666da5dd174)
 
 ```bash
   git checkout -b <name-of-new-branch>

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can ask questions by raising an [issue](https://github.com/EddieHubCommunity
 - Go to your profile. You will find forked repo named **_open-source-practice_**. go to the repo by clicking on it.
 - Click on the green Code button, then either the HTTPS or SSH option, and, click the icon to copy the URL. Now you have a copy of the project. Thus, you can play around with it locally on your computer.
 
-- Run the following commands into a terminal window (Command Prompt, Powershell, Terminal, Bash, ZSH). Do this to download the forked copy of this repository to your computer. ![git-clone](https://github.com/AmanxUpadhyay/open-source-practice/assets/76415079/4d600e25-83b1-4e8f-9325-f1adc4f8ce3d)
+- Run the following commands into a terminal window (Command Prompt, Powershell, Terminal, Bash, ZSH). Do this to download the forked copy of this repository to your computer. ![git-clone](https://github.com/AmanxUpadhyay/hacktoberfest-practice/assets/76415079/4d600e25-83b1-4e8f-9325-f1adc4f8ce3d)
 
 ```bash
   git clone https://github.com/YOUR_GITHUB_USERNAME/hacktoberfest-practice.git

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ or
 ```
 
 - The response should be like this:
-  ![git-status](https://github.com/AmanxUpadhyay/open-source-practice/assets/76415079/d3692bcd-02d9-47d7-9e6c-b386b0a6c72d)
+  ![git-status](https://github.com/AmanxUpadhyay/hacktoberfest-practice/assets/76415079/d3692bcd-02d9-47d7-9e6c-b386b0a6c72d)
 
 ```bash
 On branch <name-of-your-branch>

--- a/README.md
+++ b/README.md
@@ -2484,7 +2484,6 @@ A GitHub conflict is when people make changes to the same area or line in a file
   - [Vrukshali Torawane](https://github.com/Vrukshali-26)
   - [VulcanWM](https://github.com/VulcanWM)
   - [Vurugonda Kalyan](https://github.com/kalyan-vurugonda)
-  
 
 | [`Back To Top`](#contents) |
 

--- a/README.md
+++ b/README.md
@@ -2411,7 +2411,6 @@ A GitHub conflict is when people make changes to the same area or line in a file
 - ### **V**
 
   - [Vaibhav Lakhera](https://github.com/vaibhav-init)
-  - [Vishesh Tiwari](https://github.com/vishesh-hue)
   - [Vaibhav Malhotra](https://github.com/vaibhavmalhotra002)
   - [Vaibhav Sharma](https://github.com/AlphaVS-76)
   - [Vaibhav Tiwari](https://github.com/vteam27)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Please make sure you have the correct access rights and that the repository exis
 
 **8. Raise a Pull Request:**
 
-- On the GitHub website, navigate to your forked repo - on the top of the files section, you'll notice a new section containing a `Compare & Pull Request` button! ![createpr](https://github.com/AmanxUpadhyay/open-source-practice/assets/76415079/0c971d35-5230-4f4a-923a-81a05c318887)
+- On the GitHub website, navigate to your forked repo - on the top of the files section, you'll notice a new section containing a `Compare & Pull Request` button! ![createpr](https://github.com/AmanxUpadhyay/hacktoberfest-practice/assets/76415079/0c971d35-5230-4f4a-923a-81a05c318887)
 
 - Click on that button, this will load a new page, comparing the local branch in your forked repository against the main branch in the EddieHub Hacktoberfest repository. Do not make any changes in the selected values of the branches (do so only if needed), and click the green `Create Pull Request` button. After creating the PR (Pull Request), our GitHub Actions workflow will add a welcome message to your PR.
   Note: A pull request allows us to merge your changes with the original project repo.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ or
 ```
 
 **6. Commit the changes:**
-![git-commit](https://github.com/AmanxUpadhyay/open-source-practice/assets/76415079/9a6a58f3-ed0b-4bc2-b749-48baede77835)
+![git-commit](https://github.com/AmanxUpadhyay/hacktoberfest-practice/assets/76415079/9a6a58f3-ed0b-4bc2-b749-48baede77835)
 
 ```bash
   git commit -m "Add <your-github-username>"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can ask questions by raising an [issue](https://github.com/EddieHubCommunity
   git clone https://github.com/YOUR_GITHUB_USERNAME/hacktoberfest-practice.git
 ```
 
-- Switch to the cloned folder. You can paste this command into the same terminal window. ![opening-vscode](https://github.com/AmanxUpadhyay/open-source-practice/assets/76415079/1a8b350d-0c96-461a-85f4-a59185aed6b6)
+- Switch to the cloned folder. You can paste this command into the same terminal window. ![opening-vscode](https://github.com/AmanxUpadhyay/hacktoberfest-practice/assets/76415079/1a8b350d-0c96-461a-85f4-a59185aed6b6)
 
 ```bash
   cd hacktoberfest-practice

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ or
   git push -u origin main
 ```
 
-![git-push](https://github.com/AmanxUpadhyay/open-source-practice/assets/76415079/f1cec12f-ea26-4986-a820-7881bc69f764)
+![git-push](https://github.com/AmanxUpadhyay/hacktoberfest-practice/assets/76415079/f1cec12f-ea26-4986-a820-7881bc69f764)
 
 > **Warning**: If you get an error message like the one below, you probably forgot to fork the repository before cloning it. It is best to start over and fork the project repository first.
 

--- a/README.md
+++ b/README.md
@@ -2465,6 +2465,7 @@ A GitHub conflict is when people make changes to the same area or line in a file
   - [Vishal M](https://github.com/Mvishal123)
   - [Vishal Rathore](https://github.com/vishalcoder139)
   - [Vishal Rathore](https://github.com/vishalrathore8oct)
+  - [Vishesh Tiwari](https://github.com/vishesh-hue)
   - [Vishnu](https://github.com/shukl08vk)
   - [Vishnupriya](https://github.com/Vishnupriya119)
   - [Vishwa S](https://github.com/VishwaS-22)

--- a/README.md
+++ b/README.md
@@ -2409,6 +2409,7 @@ A GitHub conflict is when people make changes to the same area or line in a file
 | [`Back To Top`](#contents) |
 
 - ### **V**
+
   - [Vaibhav Lakhera](https://github.com/vaibhav-init)
   - [Vishesh Tiwari](https://github.com/vishesh-hue)
   - [Vaibhav Malhotra](https://github.com/vaibhavmalhotra002)

--- a/README.md
+++ b/README.md
@@ -2409,7 +2409,6 @@ A GitHub conflict is when people make changes to the same area or line in a file
 | [`Back To Top`](#contents) |
 
 - ### **V**
-    
   - [Vaibhav Lakhera](https://github.com/vaibhav-init)
   - [Vishesh Tiwari](https://github.com/vishesh-hue)
   - [Vaibhav Malhotra](https://github.com/vaibhavmalhotra002)


### PR DESCRIPTION
closes #3144 

successfully updated all the instances  "hacktoberfest-practice" to "open-source-practice" in the readme.md file 

