### PR TITLE
[FEATURE] GitHub action to comment on pull requests

### DIFF
--- a/.github/workflows/comment-on-pull-request.yml
+++ b/.github/workflows/comment-on-pull-request.yml
@@ -1,5 +1,7 @@
 name: comment-on-pull-request
 on: pull_request
+permissions: 
+  pull-requests: write 
 jobs:
   check-bats-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/comment-on-pull-request.yml
+++ b/.github/workflows/comment-on-pull-request.yml
@@ -1,5 +1,5 @@
 name: comment-on-pull-request
-on: pull_request_target
+on: pull_request
 permissions: 
   pull-requests: write 
 jobs:

--- a/.github/workflows/comment-on-pull-request.yml
+++ b/.github/workflows/comment-on-pull-request.yml
@@ -1,9 +1,9 @@
 name: comment-on-pull-request
-on: pull_request
+on: pull_request_target
 permissions: 
   pull-requests: write 
 jobs:
-  check-bats-version:
+  comment-on-pr:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/comment-on-pull-request.yml
+++ b/.github/workflows/comment-on-pull-request.yml
@@ -11,4 +11,4 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-            This repository is for practice only, it will not count towards the hacktoberfest.
+            This repository is for **practice only**, it will not count towards the hacktoberfest.

--- a/.github/workflows/comment-on-pull-request.yml
+++ b/.github/workflows/comment-on-pull-request.yml
@@ -1,0 +1,14 @@
+name: comment-on-pull-request
+on: pull_request
+jobs:
+  check-bats-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            This repository is for practice only, it will not count towards the hacktoberfest.

--- a/.github/workflows/comment-on-pull-request.yml
+++ b/.github/workflows/comment-on-pull-request.yml
@@ -13,4 +13,4 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-            This repository is for **practice only**, it will not count towards the hacktoberfest.
+            This repository is for **practice only** and therefore it will not count towards hacktoberfest.


### PR DESCRIPTION
### Related issue
Closes #3141

### What changes does this PR do?
- The `comment-on-pull-request.yml` file initiates a GitHub Action upon every pull requests created under this repository. It comments the following message: "This repository is for **practice only**, it will not count towards the hacktoberfest." on the pull requests made.

### Screenshots
![image](https://github.com/EddieHubCommunity/open-source-practice/assets/68412863/eb1419f4-d39e-4a3c-ab74-6c5b14a68dad)


### Questions
I believe there is a slight issue with the permissions, I tested on a PR created within my forked repo (https://github.com/AnushaDeviR/hacktoberfest-practice/pull/3) and I didn't face this issue. Could you please have a look into this?