### PR TITLE
Fix Bare url used in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable-next-line -->
 
-# Note: This repository is _not_ included in the Hacktoberfest event, as it is for practice only
+# Note: This repository is _not_ included in the Hacktoberfest event, as it is for practice only!
 
 We have other [repositories](https://github.com/orgs/EddieHubCommunity/repositories) in the organization that you can contribute to. If you would like to join our GitHub organisation, raise an [issue](https://github.com/EddieHubCommunity/support/issues/new?assignees=&labels=invite+me+to+the+organisation&template=invitation.yml&title=Please+invite+me+to+the+GitHub+Community+Organization) on this repo EddieHubCommunity-Support and you can also join the EddieHub [Discord](http://discord.eddiehub.org/) channel
 
@@ -1502,7 +1502,7 @@ A GitHub conflict is when people make changes to the same area or line in a file
   - [Lokmen Farhat](https://github.com/farhatlokmen)
   - [Lordson Fernando](https://github.com/lordsonfernando)
   - [Lovakush](https://github.com/Lovakush)
-  - [Lovis](https://github.com/lovis)
+  - [Lovis](https://github.com/lovistawiah)
   - [Lovkush](https://github.com/LOVKUSH9888)
   - [Lubna Fathima N](https://github.com/lubnafathima)
   - [Lucas Montel Costa](https://github.com/lucasmontel)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable-next-line -->
 
-# Note: This repository is _not_ included in the Hacktoberfest event, as it is for practice only!
+# Note: This repository is _not_ included in the Hacktoberfest event, as it is for practice only
 
 We have other [repositories](https://github.com/orgs/EddieHubCommunity/repositories) in the organization that you can contribute to. If you would like to join our GitHub organisation, raise an [issue](https://github.com/EddieHubCommunity/support/issues/new?assignees=&labels=invite+me+to+the+organisation&template=invitation.yml&title=Please+invite+me+to+the+GitHub+Community+Organization) on this repo EddieHubCommunity-Support and you can also join the EddieHub [Discord](http://discord.eddiehub.org/) channel
 
@@ -1502,6 +1502,7 @@ A GitHub conflict is when people make changes to the same area or line in a file
   - [Lokmen Farhat](https://github.com/farhatlokmen)
   - [Lordson Fernando](https://github.com/lordsonfernando)
   - [Lovakush](https://github.com/Lovakush)
+  - [Lovis](https://github.com/lovis)
   - [Lovkush](https://github.com/LOVKUSH9888)
   - [Lubna Fathima N](https://github.com/lubnafathima)
   - [Lucas Montel Costa](https://github.com/lucasmontel)

--- a/README.md
+++ b/README.md
@@ -1118,7 +1118,7 @@ A GitHub conflict is when people make changes to the same area or line in a file
   - [Hadia Djadallah](https://github.com/liliumorion)
   - [Hafeez Pizofreude](https://github.com/pizofreude)
   - [Hammad Azam](https://github.com/hammadhz)
-  - [Hamza Haji] (https://github.com/hamzambo)
+  - [Hamza Haji](https://github.com/hamzambo)
   - [Hamza Jassar](https://github.com/iJassar)
   - [Hamzat EngineerHamziey](https://github.com/EngineerHamziey)
   - [Hana Aliyah Mufidah](https://github.com/aliyanamu)


### PR DESCRIPTION
### Related issue
<!-- Remove this field if it doesn't fix any issue -->

### What changes does this PR do?
Fix bare url used in Readme 
```diff
-   - [Hamza Haji] (https://github.com/hamzambo)
+   - [Hamza Haji](https://github.com/hamzambo)
```
### Screenshots (If any)
![Screenshot from 2024-04-12 11-25-52](https://github.com/EddieHubCommunity/open-source-practice/assets/69266504/27fd16f2-503d-4803-975b-704c7d55f6cd)

### Questions
